### PR TITLE
Include project identifiers in API output

### DIFF
--- a/app/views/users/show.api.rsb
+++ b/app/views/users/show.api.rsb
@@ -13,7 +13,7 @@ api.user do
     @memberships.each do |membership|
       api.membership do
         api.id membership.id
-        api.project :id => membership.project.id, :name => membership.project.name
+        api.project :id => membership.project.id, :name => membership.project.name, :identifier => membership.project.identifier
         api.array :roles do
           membership.member_roles.each do |member_role|
             if member_role.role


### PR DESCRIPTION
Please consider this patch which includes project identifiers in the membership API
