### PR TITLE
Fix a "incompatible character encodings: UTF-8 and ASCII-8BIT"

### DIFF
--- a/app/views/queries/_columns.html.erb
+++ b/app/views/queries/_columns.html.erb
@@ -4,7 +4,7 @@
       <%= label_tag "available_columns", l(:description_available_columns) %>
       <br />
       <%= select_tag 'available_columns',
-              options_for_select((query.available_columns - query.columns).collect {|column| [column.caption, column.name]}),
+              options_for_select((query.available_columns - query.columns).collect {|column| [column.caption.force_encoding('UTF-8'), column.name]}),
               :multiple => true, :size => 10, :style => "width:150px",
               :ondblclick => "moveOptions(this.form.available_columns, this.form.selected_columns);" %>
     </td>
@@ -18,7 +18,7 @@
       <%= label_tag "selected_columns", l(:description_selected_columns) %>
       <br />
       <%= select_tag 'c[]',
-              options_for_select(query.columns.collect {|column| [column.caption, column.name]}),
+              options_for_select(query.columns.collect {|column| [column.caption.force_encoding('UTF-8'), column.name]}),
               :id => 'selected_columns', :multiple => true, :size => 10, :style => "width:150px",
               :ondblclick => "moveOptions(this.form.selected_columns, this.form.available_columns);" %>
     </td>


### PR DESCRIPTION
... that appeared after we renamed some columns to names with accents in Redmine administrative interface.
