### PR TITLE
fill username when authentification failed

### DIFF
--- a/app/views/account/login.html.erb
+++ b/app/views/account/login.html.erb
@@ -5,7 +5,7 @@
 <table>
 <tr>
     <td align="right"><label for="username"><%=l(:field_login)%>:</label></td>
-    <td align="left"><%= text_field_tag 'username', nil, :tabindex => '1' %></td>
+    <td align="left"><%= text_field_tag 'username', params[:username], :tabindex => '1' %></td>
 </tr>
 <tr>
     <td align="right"><label for="password"><%=l(:field_password)%>:</label></td>


### PR DESCRIPTION
If you have a large and difficult the password, it is often mistaken for the input. After post form the password must also fill out and the name, it is not convenient
