### PR TITLE
autologin if have back_url

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -25,7 +25,11 @@ class AccountController < ApplicationController
   # Login request and validation
   def login
     if request.get?
-      logout_user
+      if User.current.logged? and params.include? "back_url"
+        redirect_to back_url
+      else
+        logout_user
+      end
     else
       authenticate_user
     end


### PR DESCRIPTION
Example, when user run browser with a lot of old tabs of redmine, he see in each 'login form'. He fills one of them  falls into a redmine. When it updates the other tab, where the url like a 'login?back_url=<url>' is triggered to autologout. But he wanted to go to <url>.
I'm fix this. If user logged and have back_url he will be redirect to <url> as he wants
