### PR TITLE
'error' is not a string and cannot concat

### DIFF
--- a/lib/tasks/load_default_data.rake
+++ b/lib/tasks/load_default_data.rake
@@ -28,7 +28,7 @@ namespace :redmine do
     rescue Redmine::DefaultData::DataAlreadyLoaded => error
       puts error
     rescue => error
-      puts "Error: " + error
+      puts "Error: " + error.inspect
       puts "Default configuration data was not loaded."
     end
   end


### PR DESCRIPTION
load_default_data fails to print the error message if one occurs
