### PR TITLE
use request.format instead of request[:format]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,7 +94,7 @@ class ApplicationController < ActionController::Base
         user = (User.active.find(session[:user_id]) rescue nil)
       elsif autologin_user = try_to_autologin
         user = autologin_user
-      elsif params[:format] == 'atom' && params[:key] && request.get? && accept_rss_auth?
+      elsif request.format == 'atom' && params[:key] && request.get? && accept_rss_auth?
         # RSS key authentication does not start a session
         user = User.find_by_rss_key(params[:key])
       end
@@ -490,7 +490,7 @@ class ApplicationController < ActionController::Base
   end
 
   def api_request?
-    %w(xml json).include? params[:format]
+    %w(xml json).include? request.format
   end
 
   # Returns the API key present in the request


### PR DESCRIPTION
Allow request headers to determine the format, not just URL extension
