### PR TITLE
Fixes migration from newer versions of Mantisbt that use unix timestamp for date fields.

### DIFF
--- a/lib/tasks/migrate_from_mantis.rake
+++ b/lib/tasks/migrate_from_mantis.rake
@@ -136,7 +136,7 @@ task :migrate_from_mantis => :environment do
     end
 
     class MantisCategory < ActiveRecord::Base
-      self.table_name = :mantis_project_category_table
+      self.table_name = :mantis_category_table
     end
 
     class MantisProjectUser < ActiveRecord::Base
@@ -245,7 +245,7 @@ task :migrate_from_mantis => :environment do
         u = User.new :firstname => encode(user.firstname),
                      :lastname => encode(user.lastname),
                      :mail => user.email,
-                     :last_login_on => user.last_visit
+                     :last_login_on => Time.at(user.last_visit).to_datetime
         u.login = user.username
         u.password = 'mantis'
         u.status = User::STATUS_LOCKED if user.enabled != 1
@@ -286,7 +286,7 @@ task :migrate_from_mantis => :environment do
         project.versions.each do |version|
           v = Version.new :name => encode(version.version),
                           :description => encode(version.description),
-                          :effective_date => (version.date_order ? version.date_order.to_date : nil)
+                          :effective_date => (version.date_order ? Time.at(version.date_order).to_date : nil)
           v.project = p
           v.save
           versions_map[version.id] = v.id
@@ -294,10 +294,10 @@ task :migrate_from_mantis => :environment do
 
         # Project categories
         project.categories.each do |category|
-          g = IssueCategory.new :name => category.category[0,30]
+          g = IssueCategory.new :name => category.name[0,30]
           g.project = p
           g.save
-          categories_map[category.category] = g.id
+          categories_map[category.name] = g.id
         end
       end
       puts
@@ -313,10 +313,10 @@ task :migrate_from_mantis => :environment do
                       :subject => encode(bug.summary),
                       :description => encode(bug.bug_text.full_description),
                       :priority => PRIORITY_MAPPING[bug.priority] || DEFAULT_PRIORITY,
-                      :created_on => bug.date_submitted,
-                      :updated_on => bug.last_updated
+                      :created_on => Time.at(bug.date_submitted).to_datetime,
+                      :updated_on => Time.at(bug.last_updated).to_datetime
         i.author = User.find_by_id(users_map[bug.reporter_id])
-        i.category = IssueCategory.find_by_project_id_and_name(i.project_id, bug.category[0,30]) unless bug.category.blank?
+        i.category = IssueCategory.find_by_project_id_and_name(i.project_id, bug.category_id) unless bug.category_id.blank?
         i.fixed_version = Version.find_by_project_id_and_name(i.project_id, bug.fixed_in_version) unless bug.fixed_in_version.blank?
         i.status = STATUS_MAPPING[bug.status] || DEFAULT_STATUS
         i.tracker = (bug.severity == 10 ? TRACKER_FEATURE : TRACKER_BUG)
@@ -337,7 +337,7 @@ task :migrate_from_mantis => :environment do
         bug.bug_notes.each do |note|
           next unless users_map[note.reporter_id]
           n = Journal.new :notes => encode(note.bug_note_text.note),
-                          :created_on => note.date_submitted
+                          :created_on => Time.at(note.date_submitted).to_datetime
           n.user = User.find_by_id(users_map[note.reporter_id])
           n.journalized = i
           n.save
@@ -345,7 +345,7 @@ task :migrate_from_mantis => :environment do
 
         # Bug files
         bug.bug_files.each do |file|
-          a = Attachment.new :created_on => file.date_added
+          a = Attachment.new :created_on => Time.at(file.date_added).to_datetime
           a.file = file
           a.author = User.find :first
           a.container = i
@@ -384,7 +384,7 @@ task :migrate_from_mantis => :environment do
         n = News.new :project_id => projects_map[news.project_id],
                      :title => encode(news.headline[0..59]),
                      :description => encode(news.body),
-                     :created_on => news.date_posted
+                     :created_on => Time.at(news.date_posted).to_datetime
         n.author = User.find_by_id(users_map[news.poster_id])
         n.save
         print '.'


### PR DESCRIPTION
Fixes migration from newer versions of Mantis that use unix timestamp for date fields.

tested with:
Ruby version                             1.9.3 (x86_64-darwin12.0.0)
Rails version                            3.2.6

Mantis 1.12.11 schema version 185

Redmine Environment:
Redmine version                          2.0.3.devel
Database adapter                         Mysql2
