### PR TITLE
Use 12:00 as a reference point for simple dates instead of midnight. (#4025)

### DIFF
--- a/public/javascripts/calendar/calendar.js
+++ b/public/javascripts/calendar/calendar.js
@@ -1589,7 +1589,7 @@ Date.parseDate = function(str, fmt) {
 	var a = str.split(/\W+/);
 	var b = fmt.match(/%./g);
 	var i = 0, j = 0;
-	var hr = 0;
+	var hr = 12;
 	var min = 0;
 	for (i = 0; i < a.length; ++i) {
 		if (!a[i])


### PR DESCRIPTION
In locales where DST timezone changes occur on midnight (like Brazil) the calendar becomes confused which date to show. On DST ends, the date sprung back from 2010-10-17 00:00 to 2010-10-16 23:00 in Brazil. Thus, the date 2010-10-16 was shown two times. Using 12 as the default hour for dates does circumvent this issue. If DST changes occur around noon or the time picker functionality is used, this still breaks however.
